### PR TITLE
ci: skip testing against ROOT until root conda-forge issue 253 is fixed.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
         with:
           environment-name: test-env
           create-args: >-
-            python=${{ matrix.python-version }} pip root
+            python=${{ matrix.python-version }} pip
       - name: Install Python dependencies
         run: |
           which python
@@ -70,7 +70,7 @@ jobs:
         with:
           environment-name: test-env
           create-args: >-
-            python=${{ matrix.python-version }} pip root
+            python=${{ matrix.python-version }} pip
       - name: Install Python dependencies
         run: |
           which python

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,14 +42,13 @@ jobs:
         with:
           environment-name: test-env
           create-args: >-
-            python=${{ matrix.python-version }} pip ${{ matrix.python-version != '3.12' && 'root' || '' }}
+            python=${{ matrix.python-version }} pip root
       - name: Install Python dependencies
         run: |
           which python
           python -V
           python -m pip install uv
           python -m uv pip install -e ".[dev]"
-          python -m uv pip install git+https://github.com/HDembinski/numba-stats.git
       - name: Test with pytest
         run: |
           coverage run --source=. --omit=".tox/*" --branch -m pytest .
@@ -71,14 +70,13 @@ jobs:
         with:
           environment-name: test-env
           create-args: >-
-            python=${{ matrix.python-version }} pip ${{ matrix.python-version != '3.12' && 'root' || '' }}
+            python=${{ matrix.python-version }} pip root
       - name: Install Python dependencies
         run: |
           which python
           python -V
           python -m pip install uv
           python -m uv pip install -e ".[dev]"
-          python -m uv pip install git+https://github.com/HDembinski/numba-stats.git
       - name: Test with pytest
         run: |
           ZFIT_DO_JIT=0

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -3,7 +3,7 @@ coverage>=4.5.1
 flake8>=3.5.0
 jupyter-sphinx
 myst-nb
-numba-stats  # hack for pypi release, doesn't allow git repos @ git+https://github.com/HDembinski/numba-stats.git  # CMSShape not yet released (expected 1.8.0)
+numba-stats
 pip>=9.0.1
 pre-commit
 pydata-sphinx-theme>=0.9  # new dark theme configuration

--- a/tests/test_pdf_novosibirsk.py
+++ b/tests/test_pdf_novosibirsk.py
@@ -2,6 +2,7 @@
 
 import numpy as np
 import pytest
+import ROOT
 import tensorflow as tf
 import zfit
 from zfit.core.testing import tester
@@ -27,7 +28,6 @@ def create_novosibirsk(mu, sigma, lambd, limits):
 
 @pytest.mark.skip
 def create_and_eval_root_novosibirsk_and_integral(mu, sigma, lambd, limits, x, lower, upper):
-    ROOT = pytest.importorskip("ROOT")
     obs = ROOT.RooRealVar("obs", "obs", *limits)
     peak = ROOT.RooRealVar("peak", "peak", mu)
     width = ROOT.RooRealVar("width", "width", sigma)

--- a/tests/test_pdf_novosibirsk.py
+++ b/tests/test_pdf_novosibirsk.py
@@ -27,7 +27,7 @@ def create_novosibirsk(mu, sigma, lambd, limits):
     novosibirsk = zphys.pdf.Novosibirsk(mu=mu, sigma=sigma, lambd=lambd, obs=obs)
     return novosibirsk, obs
 
-@pytest.mark.skip
+
 def create_and_eval_root_novosibirsk_and_integral(mu, sigma, lambd, limits, x, lower, upper):
     obs = ROOT.RooRealVar("obs", "obs", *limits)
     peak = ROOT.RooRealVar("peak", "peak", mu)

--- a/tests/test_pdf_novosibirsk.py
+++ b/tests/test_pdf_novosibirsk.py
@@ -2,7 +2,8 @@
 
 import numpy as np
 import pytest
-import ROOT
+
+ROOT = pytest.importorskip("ROOT")
 import tensorflow as tf
 import zfit
 from zfit.core.testing import tester


### PR DESCRIPTION
We know the Novosibirsk implementation works.
Let's skipping testing it against root until https://github.com/conda-forge/root-feedstock/issues/253 is fixed to make to get the ci working again.