### PR TITLE
fix: pyhf NLLs returning 1-element arrays instead of scalars + CI fixes and improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,8 +50,8 @@ jobs:
         name: Set up Micromamba environment
         with:
           environment-name: test-env
-          create-args: >-
-            python=${{ matrix.python-version }} pip uv ${{ matrix.os != 'windows-latest' && 'root' || '' }}
+          create-args: >-  # PyROOT and TensorFlow have an LLVM symbol collision on macOS
+            python=${{ matrix.python-version }} pip uv ${{ matrix.os == 'ubuntu-latest' && 'root' || '' }}
       - name: Install Python dependencies
         run: |
           which python

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,8 +50,8 @@ jobs:
         name: Set up Micromamba environment
         with:
           environment-name: test-env
-          create-args: >-  # PyROOT and TensorFlow have an LLVM symbol collision on macOS
-            python=${{ matrix.python-version }} pip uv ${{ matrix.os == 'ubuntu-latest' && 'root' || '' }}
+          create-args: >-
+            python=${{ matrix.python-version }} pip uv ${{ matrix.os != 'windows-latest' && 'root' || '' }}
       - name: Install Python dependencies
         run: |
           which python

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,14 +34,14 @@ jobs:
       fail-fast: False
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
-        python-version: [ "3.10" ]
+        python-version: [ "3.10", "3.13" ]
         jit: [ "1" ]
         include:
           - os: ubuntu-latest
-            python-version: "3.13"
-            jit: 1
-          - os: ubuntu-latest
             python-version: "3.10"
+            jit: 0
+          - os: ubuntu-latest
+            python-version: "3.13"
             jit: 0
     name: Tests on OS ${{ matrix.os }} with Python ${{ matrix.python-version }} and JIT ${{ matrix.jit }}
     steps:
@@ -50,15 +50,17 @@ jobs:
         name: Set up Micromamba environment
         with:
           environment-name: test-env
-          create-args: >-  # install ROOT only on non-windows
-            python=${{ matrix.python-version }} pip uv ${{ matrix.os != 'windows-latest' && 'root' || '' }}
+          create-args: >-  # PyROOT and TensorFlow have an LLVM symbol collision on macOS
+            python=${{ matrix.python-version }} pip uv ${{ matrix.os == 'ubuntu-latest' && 'root' || '' }}
       - name: Install Python dependencies
         run: |
           which python
           python -V
           uv pip install -e ".[dev]" zfit@git+https://github.com/zfit/zfit
       - name: Test with pytest
+        env:
+          PYTHONUNBUFFERED: "1"
+          ZFIT_DO_JIT: ${{ matrix.jit }}
         run: |
-          ZFIT_DO_JIT=${{ matrix.jit }}
-          coverage run --source=. --omit=".tox/*" --branch -m pytest .
+          coverage run --source=. --omit=".tox/*" --branch -m pytest -vv .
           coverage report

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,10 +39,10 @@ jobs:
         include:
           - os: ubuntu-latest
             python-version: "3.10"
-            jit: 0
+            jit: "0"
           - os: ubuntu-latest
             python-version: "3.13"
-            jit: 0
+            jit: "0"
     name: Tests on OS ${{ matrix.os }} with Python ${{ matrix.python-version }} and JIT ${{ matrix.jit }}
     steps:
       - uses: actions/checkout@v6

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -69,12 +69,6 @@ repos:
         args:
           - --py39-plus
 
-  - repo: https://github.com/sondrelg/pep585-upgrade
-    rev: v1.0
-    hooks:
-      - id: upgrade-type-hints
-        args:
-          - --futures=true
   - repo: https://github.com/MarcoGorelli/auto-walrus
     rev: 0.3.4
     hooks:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,7 +7,7 @@ version: 2
 build:
   os: ubuntu-lts-latest
   tools:
-    python: "mambaforge-latest"
+    python: "miniforge3-latest"
 
 
 

--- a/docs/api/static/zfit_physics.roofit.rst
+++ b/docs/api/static/zfit_physics.roofit.rst
@@ -20,6 +20,7 @@ For example via conda:
     from ROOT import RooArgSet, RooDataSet, RooGaussian, RooRealVar
 
     data = np.random.normal(loc=2.0, scale=3.0, size=1000)
+    data = data[(data >= -2) & (data <= 3)]
 
     mur = RooRealVar("mu", "mu", 1.2, -4, 6)
     sigmar = RooRealVar("sigma", "sigma", 1.3, 0.5, 10)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,7 @@ dev = [
     "flake8>=3.5.0",
     "jupyter-sphinx",
     "myst-nb",
+    "numba>=0.61",
     "numba-stats",
     "pip>=9.0.1",
     "pre-commit",

--- a/src/zfit_physics/pyhf/loss.py
+++ b/src/zfit_physics/pyhf/loss.py
@@ -42,6 +42,6 @@ def nll_from_pyhf(data, pdf, *, params=None, init_pars=None, par_bounds=None, fi
 
     def nll_func(params, *, data=data, pdf=pdf, errordef=errordef):
         params = np.asarray(params)
-        return mle.twice_nll(params, data, pdf) * errordef
+        return mle.twice_nll(params, data, pdf)[0] * errordef
 
     return zfit.loss.SimpleLoss(func=nll_func, params=params, errordef=errordef, gradient="num", jit=False)

--- a/tests/pyhf/test_pyhf_loss.py
+++ b/tests/pyhf/test_pyhf_loss.py
@@ -42,6 +42,7 @@ def test_nll_from_pyhf_simple():
     data = datanp + pdf.config.auxdata
 
     nll = zpyhf.loss.nll_from_pyhf(data, pdf)
+    assert nll.value().shape == ()
 
     minimizer = zfit.minimize.Minuit(verbosity=7)
     resultz = minimizer.minimize(nll)
@@ -50,4 +51,4 @@ def test_nll_from_pyhf_simple():
         data, pdf, pdf.config.suggested_init(), pdf.config.suggested_bounds(), return_fitted_val=True
     )
     assert np.allclose(resultz.fmin, fmin / 2, atol=1e-4)
-    np.testing.assert_allclose(resultz.values, values, atol = 5e-3)
+    np.testing.assert_allclose(resultz.values, values, atol=5e-3)

--- a/tests/pyhf/test_pyhf_loss.py
+++ b/tests/pyhf/test_pyhf_loss.py
@@ -42,7 +42,7 @@ def test_nll_from_pyhf_simple():
     data = datanp + pdf.config.auxdata
 
     nll = zpyhf.loss.nll_from_pyhf(data, pdf)
-    assert nll.value().shape == ()
+    assert nll.value().shape == ()  # nosec B101
 
     minimizer = zfit.minimize.Minuit(verbosity=7)
     resultz = minimizer.minimize(nll)

--- a/tests/roofit/test_loss_compat_roofit.py
+++ b/tests/roofit/test_loss_compat_roofit.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
 
-_ = pytest.importorskip("ROOT")
+pytest.importorskip("ROOT")
 
 
 def test_loss_registry():

--- a/tests/test_pdf_novosibirsk.py
+++ b/tests/test_pdf_novosibirsk.py
@@ -3,7 +3,7 @@
 import numpy as np
 import pytest
 
-ROOT = pytest.importorskip("ROOT")
+pytest.importorskip("ROOT")
 import tensorflow as tf
 import zfit
 from zfit.core.testing import tester
@@ -29,6 +29,8 @@ def create_novosibirsk(mu, sigma, lambd, limits):
 
 
 def create_and_eval_root_novosibirsk_and_integral(mu, sigma, lambd, limits, x, lower, upper):
+    import ROOT
+
     obs = ROOT.RooRealVar("obs", "obs", *limits)
     peak = ROOT.RooRealVar("peak", "peak", mu)
     width = ROOT.RooRealVar("width", "width", sigma)


### PR DESCRIPTION
Pyhf is returning 1D 1-element arrays while zfit loss expects a scalar